### PR TITLE
Add option to load ATOR config automatically on startup

### DIFF
--- a/src/main/java/burp/BurpExtender.java
+++ b/src/main/java/burp/BurpExtender.java
@@ -1,9 +1,15 @@
 package burp;
 
+import burp.ImportATOR;
 import javax.swing.*;
 import java.awt.*;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Properties;
+import java.util.Map;
+import java.io.File;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
 
 
 public class BurpExtender implements IBurpExtender, IContextMenuFactory, ITab,  IHttpListener {
@@ -40,8 +46,18 @@ public class BurpExtender implements IBurpExtender, IContextMenuFactory, ITab,  
         extension.append("[*] ");
         extension.append(EXTENSION_NAME);
         
+		// Load default JSON config, if available
+		ImportATOR importer = new ImportATOR(callbacks);
+		String filepath = System.getenv().get("ATOR_CONFIG_FILEPATH");
+		if(filepath != null) {
+			File f = new File(filepath);
+			if(f.exists() && !f.isDirectory()) {
+				importer.loadJSONFile(filepath);
+				callbacks.printOutput("ATOR configuration loaded successfully from " + filepath);
+			}
+		}
         callbacks.printOutput("ATOR loaded successfully");
-     }
+    }
 
 	public BurpExtender getComponent() {
 		return BurpExtender.this;

--- a/src/main/java/burp/ImportATOR.java
+++ b/src/main/java/burp/ImportATOR.java
@@ -24,36 +24,37 @@ public class ImportATOR {
 	
 	public void readJSONFile() {
 		String filePath = null;
-        JFileChooser fileSelector = new JFileChooser(FileSystemView.getFileSystemView().getHomeDirectory()); 
-        int fileChoosenState = fileSelector.showOpenDialog(null); 
-        if (fileChoosenState == JFileChooser.APPROVE_OPTION) 
-        	filePath = fileSelector.getSelectedFile().getAbsolutePath(); 
-        if(filePath != null)
-        {
-        	SetttingsTab.importATORFile.setText(filePath);
-        	JSONParser jsonParser = new JSONParser();
-         
-	        try (FileReader reader = new FileReader(filePath))
-	        {
-	        	JSONObject jsonObject = (JSONObject) jsonParser.parse(reader);
-	        	
-	        	JSONObject errorCondition = (JSONObject) jsonObject.get("errorCondition");
-	        	
-	        	parseErrorCondition(errorCondition);
-	        	
-	        	JSONObject obtainToken = (JSONObject) jsonObject.get("obtainToken");
-	        	parseObtainToken(obtainToken);
-	        	JSONObject errorConditionReplacement = (JSONObject) jsonObject.get("errorConditionReplacement");
-	        	parseErrorConditionReplacement(errorConditionReplacement);
-	        	
-	        }
-	        catch(Exception exp) {
-	        	callbacks.printOutput("Exception while importing file.."+ exp.getMessage());
-	        }
-       }
-        
+		JFileChooser fileSelector = new JFileChooser(FileSystemView.getFileSystemView().getHomeDirectory()); 
+		int fileChoosenState = fileSelector.showOpenDialog(null); 
+		if (fileChoosenState == JFileChooser.APPROVE_OPTION)
+			filePath = fileSelector.getSelectedFile().getAbsolutePath(); 
+		if(filePath != null)
+		{
+			loadJSONFile(filePath);
+		}
 	}
 	
+	public void loadJSONFile(String filePath) {
+		SetttingsTab.importATORFile.setText(filePath);
+		JSONParser jsonParser = new JSONParser();
+
+		try (FileReader reader = new FileReader(filePath))
+		{
+			JSONObject jsonObject = (JSONObject) jsonParser.parse(reader);
+
+			JSONObject errorCondition = (JSONObject) jsonObject.get("errorCondition");
+
+		    parseErrorCondition(errorCondition);
+
+			JSONObject obtainToken = (JSONObject) jsonObject.get("obtainToken");
+			parseObtainToken(obtainToken);
+			JSONObject errorConditionReplacement = (JSONObject) jsonObject.get("errorConditionReplacement");
+			parseErrorConditionReplacement(errorConditionReplacement);
+	    }
+        catch(Exception exp) {
+			callbacks.printOutput("Exception while importing file.."+ exp.getMessage());
+        }
+	}
 	
 	public void parseErrorCondition(JSONObject jsonObject) {
 		


### PR DESCRIPTION
I added an option to configure a filepath using `ATOR_CONFIG_FILEPATH` environment variable.

I am using ATOR to run authenticated Burp scans, and loading in the configuration file manually does not work well with automation efforts. I decided to modify the module instead to allow this type of config load on startup.

If it's useful for ATOR, I hope this can be merged, so I don't need to maintain a separate fork of the project for my use-case 👍

I also opened this PR to the main repo, because I didn't see much activity on pending PRs. Hopefully we can discuss the viability and usefulness of this feature on one of these PRs and get it merged https://github.com/synopsys-sig/ATOR-Burp/pull/47/.